### PR TITLE
Add BasicParsing to check-windows-http

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ## [Unreleased]
 
 
+## [3.0.4] - 2019-10-11
+### Changed
+- updated check: `powershell/check-windows-http.ps1` added optional switch parameter `BasicParsing` to provide ability to bypass IE rendering of response and get around Internet Explorer Enhanced Security Configuration /  and trusted sites requirements (@polymorcodeus)
+
 ## [3.0.0] - 2019-03-04
 ### Security
 - updated yard dependency to `~> 0.9.11` per: https://nvd.nist.gov/vuln/detail/CVE-2017-17042 (@majormoses)

--- a/bin/check-windows-http.ps1
+++ b/bin/check-windows-http.ps1
@@ -15,8 +15,10 @@
 #
 # USAGE:
 #   Powershell.exe -NonInteractive -NoProfile -ExecutionPolicy Bypass -NoLogo -File C:\\etc\\sensu\\plugins\\check-windows-http.ps1 https://google.com
+#   Powershell.exe -ExecutionPolicy Bypass check-windows-http.ps1 https://google.com -BasicParsing
 #
 # NOTES:
+#    Use switch '-BasicParsing' to ignore IE rendering of response - invalid or blocked rendering may cause false Critical for check.
 #
 # LICENSE:
 #   Copyright 2016 sensu-plugins
@@ -26,14 +28,16 @@
 [CmdletBinding()]
 Param(
   [Parameter(Mandatory=$True,Position=1)]
-   [string]$CheckAddress
+   [string]$CheckAddress,
+  [Parameter(Mandatory=$False,Position=2)]
+   [switch]$BasicParsing
 )
 
 $ThisProcess = Get-Process -Id $pid
 $ThisProcess.PriorityClass = "BelowNormal"
 
 try {
-  $Available = Invoke-WebRequest $CheckAddress -ErrorAction SilentlyContinue
+  $Available = Invoke-WebRequest $CheckAddress -ErrorAction SilentlyContinue -UseBasicParsing:$BasicParsing
 }
 
 catch {


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
  Had already created a fix that we've deployed and decided should prolly push it back up so that if anyone else came across it, would only need a syntax change. 

#### General

- [ X ] Update Changelog following the conventions laid out on [Our CHANGELOG Guidelines ](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ X ] Update README with any necessary configuration snippets - not needed

- [ X ] Binstubs are created if needed - not needed

- [ X ] RuboCop passes - powershell script change, not applicable

- [ X ] Existing tests pass - no tests that I am aware of

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Gives option to 'UseBasicParsing' for Invoke-WebRequest on check-windows-http.ps1. Without the switch, Powershell uses IE to render the response and can cause false Criticals as it treats the blocked response as a $null. You can add powershell as a trusted site, but then requires server configuration, rather than just empowering the check to run without leveraging IE. The switch is only useful for pre-PS6.0.0.

In Powershell 6.0.0 Invoke-WebRequest ONLY does basic parsing, and including it or not is completely ignored: 
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-6

> **-UseBasicParsing**
> This parameter has been deprecated. Beginning with PowerShell 6.0.0, all Web requests use basic parsing only. This parameter is included for backwards compatibility only and any use of it has no effect on the operation of the cmdlet.

#### Known Compatibility Issues
